### PR TITLE
Inclui o número digitado, quando par

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,7 +12,7 @@ namespace SequenciaPares
             valor = int.Parse(Console.ReadLine());
             Console.WriteLine();
 
-            for (int i = 0; i < valor; i = i + 2)
+            for (int i = 0; i <= valor; i = i + 2)
             {
                 Console.Write($"{i} ");
             }


### PR DESCRIPTION
Adiciona a condição do loop como menor ou "igual a", para exibir também o número digitado.